### PR TITLE
fixes to the subframes integration test

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -60,6 +60,7 @@ COMPONENTS
   tf2_eigen
   tf2_geometry_msgs
   eigen_stl_containers
+  eigen_conversions
   geometric_shapes
   geometry_msgs
   kdl_parser

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -24,6 +24,7 @@
   <depend>eigen</depend>
   <depend>bullet</depend>
   <depend>eigen_stl_containers</depend>
+  <depend>eigen_conversions</depend>
   <depend>libfcl-dev</depend>
   <depend version_gte="0.5.2">geometric_shapes</depend>
   <depend>geometry_msgs</depend>

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -50,16 +50,16 @@ namespace core
 class AttachedBody;
 typedef boost::function<void(AttachedBody* body, bool attached)> AttachedBodyCallback;
 
-/** @brief Object defining bodies that can be attached to robot
- *  links. This is useful when handling objects picked up by
- *  the robot. */
+/** @brief Object defining bodies that can be attached to robot links.
+ *
+ * This is useful when handling objects picked up by the robot. */
 class AttachedBody
 {
 public:
-  /** \brief Construct an attached body for a specified \e link. The name of this body is \e id and it consists of \e
-     shapes that
-      attach to the link by the transforms \e attach_trans. The set of links that are allowed to be touched by this
-     object is specified by \e touch_links. */
+  /** \brief Construct an attached body for a specified \e link.
+   *
+   * The name of this body is \e id and it consists of \e shapes that attach to the link by the transforms
+   * \e attach_trans. The set of links that are allowed to be touched by this object is specified by \e touch_links. */
   AttachedBody(const LinkModel* link, const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
                const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
                const trajectory_msgs::JointTrajectory& attach_posture,
@@ -105,25 +105,30 @@ public:
     return detach_posture_;
   }
 
-  /** \brief Get the fixed transforms (the transforms to the shapes associated with this body) */
+  /** \brief Get the fixed transforms (the transforms to the shapes of this body, relative to the link) */
   const EigenSTL::vector_Isometry3d& getFixedTransforms() const
   {
     return attach_trans_;
   }
 
-  /** \brief Get subframes of this object. */
+  /** \brief Get subframes of this object (relative to the link) */
   const moveit::core::FixedTransformsMap& getSubframeTransforms() const
   {
     return subframe_poses_;
   }
 
-  /** \brief Set all subframes of this object. */
+  /** \brief Set all subframes of this object.
+   *
+   * Use these to define points of interest on the object to plan with
+   * (e.g. screwdriver/tip, kettle/spout, mug/base).
+   */
   void setSubframeTransforms(const moveit::core::FixedTransformsMap& subframe_poses)
   {
     subframe_poses_ = subframe_poses;
   }
 
-  /** \brief Get the fixed transform to a named subframe on this body.  Relative to parrent link.
+  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
+   *
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false). */
   const Eigen::Isometry3d& getSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
@@ -134,6 +139,7 @@ public:
   const Eigen::Isometry3d& getGlobalSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
 
   /** \brief Check whether a subframe of given @frame_name is present in this object.
+   *
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). */
   bool hasSubframeTransform(const std::string& frame_name) const;
@@ -153,7 +159,7 @@ public:
   /** \brief Set the scale for the shapes of this attached object */
   void setScale(double scale);
 
-  /** \brief Recompute global_collision_body_transform given the transform of the parent link*/
+  /** \brief Recompute global_collision_body_transform given the transform of the parent link */
   void computeTransform(const Eigen::Isometry3d& parent_link_global_transform)
   {
     for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)
@@ -183,10 +189,7 @@ private:
   /** \brief The global transforms for these attached bodies (computed by forward kinematics) */
   EigenSTL::vector_Isometry3d global_collision_body_transforms_;
 
-  /** \brief Transforms to subframes on the object. Transforms are relative to the link.
-   *  Use these to define points of interest on the object to plan with
-   *  (e.g. screwdriver/tip, kettle/spout, mug/base).
-   * */
+  /** \brief Transforms to subframes on the object. Transforms are relative to the link. */
   moveit::core::FixedTransformsMap subframe_poses_;
 
   /** \brief Transforms to subframes on the object. Transforms are relative to world.

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -144,9 +144,6 @@ public:
    * name is "screwdriver"). */
   bool hasSubframeTransform(const std::string& frame_name) const;
 
-  /** \brief Updates global subframe poses */
-  void updateGlobalSubframePoses();
-
   /** \brief Get the global transforms for the collision bodies */
   const EigenSTL::vector_Isometry3d& getGlobalCollisionBodyTransforms() const
   {
@@ -160,11 +157,7 @@ public:
   void setScale(double scale);
 
   /** \brief Recompute global_collision_body_transform given the transform of the parent link */
-  void computeTransform(const Eigen::Isometry3d& parent_link_global_transform)
-  {
-    for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)
-      global_collision_body_transforms_[i] = parent_link_global_transform * attach_trans_[i];
-  }
+  void computeTransform(const Eigen::Isometry3d& parent_link_global_transform);
 
 private:
   /** \brief The link that owns this attached body */
@@ -192,11 +185,7 @@ private:
   /** \brief Transforms to subframes on the object. Transforms are relative to the link. */
   moveit::core::FixedTransformsMap subframe_poses_;
 
-  /** \brief Transforms to subframes on the object. Transforms are relative to world.
-   *  These are updated when computeTransform is called and are used by getGlobalSubframeTransform
-   *  and hasSubframeTransform. Use these to define points of interest on the object to plan with
-   *  (e.g. screwdriver/tip, kettle/spout, mug/base).
-   * */
+  /** \brief Transforms to subframes on the object, relative to the model frame. */
   moveit::core::FixedTransformsMap global_subframe_poses_;
 };
 }

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -80,6 +80,19 @@ void AttachedBody::setScale(double scale)
   }
 }
 
+void AttachedBody::computeTransform(const Eigen::Isometry3d& parent_link_global_transform)
+{
+  // update collision body transforms
+  for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)
+    global_collision_body_transforms_[i] = parent_link_global_transform * attach_trans_[i];
+
+  // update subframe transforms
+  for (auto global = global_subframe_poses_.begin(), end = global_subframe_poses_.end(),
+            local = subframe_poses_.begin();
+       global != end; ++global, ++local)
+    global->second = parent_link_global_transform * local->second;
+}
+
 void AttachedBody::setPadding(double padding)
 {
   for (shapes::ShapeConstPtr& shape : shapes_)
@@ -140,17 +153,5 @@ bool AttachedBody::hasSubframeTransform(const std::string& frame_name) const
   return found;
 }
 
-void AttachedBody::updateGlobalSubframePoses()
-{
-  global_subframe_poses_ = subframe_poses_;
-  if (global_collision_body_transforms_.size() > 0)
-  {
-    auto global_transform = global_collision_body_transforms_[0];
-    for (auto& subframe_pose : global_subframe_poses_)
-    {
-      subframe_pose.second = global_transform * subframe_pose.second;
-    }
-  }
-}
 }  // namespace core
 }  // namespace moveit

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1052,7 +1052,6 @@ const Eigen::Isometry3d& RobotState::getFrameInfo(const std::string& frame_id, c
   // Check if an AttachedBody has a subframe with name frame_id
   for (const std::pair<std::string, AttachedBody*>& body : attached_body_map_)
   {
-    body.second->updateGlobalSubframePoses();
     const auto& transform = body.second->getGlobalSubframeTransform(frame_id, &frame_found);
     if (frame_found)
     {

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -38,5 +38,6 @@
   <build_depend>eigen</build_depend>
 
   <test_depend>moveit_resources</test_depend>
+  <test_depend>eigen_conversions</test_depend>
   <test_depend>rostest</test_depend>
 </package>

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 if (CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   find_package(rostest REQUIRED)
+  find_package(eigen_conversions REQUIRED)
 
   add_executable(test_cleanup test_cleanup.cpp)
   target_link_libraries(test_cleanup moveit_move_group_interface)
@@ -9,7 +10,8 @@ if (CATKIN_ENABLE_TESTING)
   target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
 
   add_rostest_gtest(subframes_test subframes_test.test subframes_test.cpp)
-  target_link_libraries(subframes_test moveit_move_group_interface ${catkin_LIBRARIES})
+  target_link_libraries(subframes_test moveit_move_group_interface
+	                     ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
 
   add_rostest(python_move_group.test)
   add_rostest(python_move_group_ns.test)

--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -118,34 +118,34 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   box.subframe_poses[0].position.z = 0.0 + z_offset_box;
 
   tf2::Quaternion orientation;
-  orientation.setRPY((90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[0].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[1] = "top";
   box.subframe_poses[1].position.y = .05;
   box.subframe_poses[1].position.z = 0.0 + z_offset_box;
-  orientation.setRPY(-(90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(-90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[1].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[2] = "corner_1";
   box.subframe_poses[2].position.x = -.025;
   box.subframe_poses[2].position.y = -.05;
   box.subframe_poses[2].position.z = -.01 + z_offset_box;
-  orientation.setRPY((90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[2].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[3] = "corner_2";
   box.subframe_poses[3].position.x = .025;
   box.subframe_poses[3].position.y = -.05;
   box.subframe_poses[3].position.z = -.01 + z_offset_box;
-  orientation.setRPY((90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[3].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[4] = "side";
   box.subframe_poses[4].position.x = .0;
   box.subframe_poses[4].position.y = .0;
   box.subframe_poses[4].position.z = -.01 + z_offset_box;
-  orientation.setRPY(0, (180.0 / 180.0 * M_PI), 0);
+  orientation.setRPY(0, 180.0 / 180.0 * M_PI, 0);
   box.subframe_poses[4].orientation = tf2::toMsg(orientation);
 
   ROS_INFO_STREAM_NAMED(log_name, "box: " << box);
@@ -163,7 +163,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   cylinder.primitive_poses[0].position.x = 0.0;
   cylinder.primitive_poses[0].position.y = 0.0;
   cylinder.primitive_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, (90.0 / 180.0 * M_PI), 0);
+  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
   cylinder.primitive_poses[0].orientation = tf2::toMsg(orientation);
 
   cylinder.subframe_poses.resize(1);
@@ -172,7 +172,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   cylinder.subframe_poses[0].position.x = 0.03;
   cylinder.subframe_poses[0].position.y = 0.0;
   cylinder.subframe_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, (90.0 / 180.0 * M_PI), 0);
+  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
   cylinder.subframe_poses[0].orientation = tf2::toMsg(orientation);
 
   ROS_INFO_STREAM_NAMED(log_name, "cylinder: " << cylinder);
@@ -224,15 +224,13 @@ TEST(TestPlanUsingSubframes, SubframesTests)
   }
 
   tf2::Quaternion target_orientation;
-  target_orientation.setRPY(-(90.0 / 180.0 * M_PI), (180.0 / 180.0 * M_PI), 0);
+  target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
   geometry_msgs::PoseStamped target_pose_stamped;
+  target_pose_stamped.header.frame_id = "box/bottom";
   target_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
   target_pose_stamped.pose.position.z = Z_OFFSET;
 
-  // When constructing the target pose for the robot, we multiply the quaternions to get the
-  // target orientation and convert the result to a geometry_msgs/orientation message.
   ROS_INFO_STREAM_NAMED(log_name, "Moving to bottom of box with cylinder tip");
-  target_pose_stamped.header.frame_id = "box/bottom";
   ASSERT_TRUE(moveToCartPose(target_pose_stamped, group, "cylinder/tip"));
   ROS_INFO_STREAM_NAMED(log_name, "Finished Moving to bottom of box with cylinder tip");
 


### PR DESCRIPTION
As https://github.com/ros-planning/moveit/pull/1757 was opened on an organizational repository,
I was not able to push directly.
I fixed the existing test. The key was to adapt the `ResolveConstraintFrames` adapter to handle the now global frames returned from `getFrameInfo()`.
Will continue to look at the original tutorial now as this needs an update as well.