### PR TITLE
Fixes for `trackjoint`

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -8,9 +8,6 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# TODO(andyz): find trackjoint library automatically
-link_directories(/home/andyz/catkin_ws/devel/lib/)
-
 find_package(Boost REQUIRED thread)
 
 find_package(catkin COMPONENTS
@@ -31,9 +28,9 @@ include_directories(
 catkin_package(
   LIBRARIES
     ${PROJECT_NAME}
-    trackjoint
   INCLUDE_DIRS include
   CATKIN_DEPENDS
+    trackjoint
     moveit_core
     actionlib
     control_msgs
@@ -48,7 +45,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERS
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
-  trackjoint
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -148,7 +148,7 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
   smoothed_goal.trajectory.header = goal.trajectory.header;
   smoothed_goal.trajectory.joint_names = goal.trajectory.joint_names;
 
-  trackjoint::ErrorCodeEnum error_code = trackjoint::ErrorCodeEnum::kNoError;
+  trackjoint::ErrorCodeEnum error_code = trackjoint::ErrorCodeEnum::NO_ERROR;
 
   double waypoint_start_time = 0;
   std::vector<trackjoint::JointTrajectory> output_trajectories(kNumDof);
@@ -167,11 +167,11 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
     std::chrono::duration<double> elapsed_seconds = end - start;
     std::cout << "Runtime: " << elapsed_seconds.count() << std::endl;
     std::cout << "Num. waypoints: " << output_trajectories.at(0).positions.size() << std::endl;
-    std::cout << "Error code: " << trackjoint::kErrorCodeMap.at(error_code)
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code)
           << std::endl;
 
     // Debug output, if failure
-    if (error_code != trackjoint::ErrorCodeEnum::kNoError)
+    if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
     {
       std::cout << "===" << std::endl;
       std::cout << "Failing conditions: " << std::endl;


### PR DESCRIPTION
### Description

This fixes a couple of compile issues I had while following the "How To Run TrackJoint on UR5" document.

The commit log shows the exact compile errors related to the TJ `ErrorCodeEnum` refactor.

The other commit removes a hard-coded path and fixes @AndyZe's build system "TODO".

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
