### PR TITLE
Reset trajectory generator after instantiating object

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -160,6 +160,10 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
                                         kMaxDuration, trackjt_current_joint_states[point],
                                         trackjt_goal_joint_states[point], limits, kPositionTolerance,
                                         kUseHighSpeedMode);
+    traj_gen.reset(kTimestep, trackjt_desired_durations[point],
+                   kMaxDuration, trackjt_current_joint_states[point],
+                   trackjt_goal_joint_states[point], limits, kPositionTolerance,
+                   kUseHighSpeedMode);
 
     auto start = std::chrono::system_clock::now();
     error_code = traj_gen.generateTrajectories(&output_trajectories);


### PR DESCRIPTION
### Description

This patch calls the `TrajectoryGenerator.reset()` method after the constructor, resetting the underlying `SingleJointGenerator()` object.  The latter's constructor no longer does that itself, and requires its own, separate `reset()` now.

This patch won't break those running TJ versions before these changes; the `reset()` will simply be redundant.

This work is still ongoing, and will change again, but this patch is required for testing the recent TJ changes in a MoveIt planning pipeline.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
